### PR TITLE
Updated to use new class name

### DIFF
--- a/header.php
+++ b/header.php
@@ -70,7 +70,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 						'menu_class'      => 'navbar-nav',
 						'fallback_cb'     => '',
 						'menu_id'         => 'main-menu',
-						'walker'          => new WP_Bootstrap_Navwalker(),
+						'walker'          => new understrap_WP_Bootstrap_Navwalker(),
 					)
 				); ?>
 


### PR DESCRIPTION
A new class name was created for the WP_Boostrap_Navwalker in the main understrap theme but the draft theme was not updated to use it.